### PR TITLE
Multiple .avs fix

### DIFF
--- a/encode.py
+++ b/encode.py
@@ -26,7 +26,7 @@ def write_avs(filename, res, file_path):
     elif res == "both":
 
         #Writes to both 1080p.avs and 720p.avs for AvspMod (both modes)
-        f = open('1080p.avs','wb')
+        f = open(filename + res + '.avs','wb')
         f.write('ffvideosource("' + path + '")\nAutoCrop(mode=0, wMultOf=4, hMultOf=2, leftAdd=0, topAdd=0, rightAdd=0, bottomAdd=0, threshold=40, samples=10, samplestartframe=0, sampleendframe=-1, aspect=0)')
         f.close()
 
@@ -54,23 +54,23 @@ def run_encode(avs_file, name, resolution):
 if resolution == "1080":
 
     #Executes the write_avs function in 1080p mode
-    write_avs('1080p.avs', '1080', path)
+    write_avs(encode_name + resolution + '.avs', '1080', path)
     extract_wav(path, audio_name)
     run_encode('1080p.avs', encode_name, '1080p')
 
 elif resolution == "720":
 
     #Executes the write_avs function in 720p mode
-    write_avs('720p.avs', '720', path)
+    write_avs(encode_name + resolution + '.avs', '720', path)
     extract_wav(path, audio_name)
     run_encode('720p.avs', encode_name, '720p')
 
 elif resolution == "both":
     #Executes the write_avs function in both modes
-    write_avs('', 'both', path)
+    write_avs(encode_name, 'both', path)
     extract_wav(path, audio_name)
-    run_encode('1080p.avs', encode_name, '1080p')
-    run_encode('720p.avs', encode_name, '720p')
+    run_encode(encode_name + '1080.avs', encode_name, '1080p')
+    run_encode(encode_name + '720.avs', encode_name, '720p')
 
 else:
     print("error")

--- a/encode.py
+++ b/encode.py
@@ -21,17 +21,17 @@ def write_avs(filename, res, file_path):
 
         #Writes to file 720p.avs for AvspMod (720p mode)
         f = open(filename,'wb')
-        f.write('ffvideosource("' + path + '")\nSpline36ResizeMod(1280, 720)\nAutoCrop(mode=0, wMultOf=4, hMultOf=2, leftAdd=0, topAdd=0, rightAdd=0, bottomAdd=0, threshold=40, samples=10, samplestartframe=0, sampleendframe=-1, aspect=0)')
+        f.write('ffvideosource("' + file_path + '")\nSpline36ResizeMod(1280, 720)\nAutoCrop(mode=0, wMultOf=4, hMultOf=2, leftAdd=0, topAdd=0, rightAdd=0, bottomAdd=0, threshold=40, samples=10, samplestartframe=0, sampleendframe=-1, aspect=0)')
 
     elif res == "both":
 
         #Writes to both 1080p.avs and 720p.avs for AvspMod (both modes)
         f = open(filename + res + '.avs','wb')
-        f.write('ffvideosource("' + path + '")\nAutoCrop(mode=0, wMultOf=4, hMultOf=2, leftAdd=0, topAdd=0, rightAdd=0, bottomAdd=0, threshold=40, samples=10, samplestartframe=0, sampleendframe=-1, aspect=0)')
+        f.write('ffvideosource("' + file_path + '")\nAutoCrop(mode=0, wMultOf=4, hMultOf=2, leftAdd=0, topAdd=0, rightAdd=0, bottomAdd=0, threshold=40, samples=10, samplestartframe=0, sampleendframe=-1, aspect=0)')
         f.close()
 
         f = open('720p.avs','wb')
-        f.write('ffvideosource("' + path + '")\nSpline36ResizeMod(1280, 720)\nAutoCrop(mode=0, wMultOf=4, hMultOf=2, leftAdd=0, topAdd=0, rightAdd=0, bottomAdd=0, threshold=40, samples=10, samplestartframe=0, sampleendframe=-1, aspect=0)')
+        f.write('ffvideosource("' + file_path + '")\nSpline36ResizeMod(1280, 720)\nAutoCrop(mode=0, wMultOf=4, hMultOf=2, leftAdd=0, topAdd=0, rightAdd=0, bottomAdd=0, threshold=40, samples=10, samplestartframe=0, sampleendframe=-1, aspect=0)')
 
     f.close()
 

--- a/encode.py
+++ b/encode.py
@@ -56,14 +56,14 @@ if resolution == "1080":
     #Executes the write_avs function in 1080p mode
     write_avs(encode_name + resolution + '.avs', '1080', path)
     extract_wav(path, audio_name)
-    run_encode('1080p.avs', encode_name, '1080p')
+    run_encode(encode_name + '1080.avs', encode_name, '1080p')
 
 elif resolution == "720":
 
     #Executes the write_avs function in 720p mode
     write_avs(encode_name + resolution + '.avs', '720', path)
     extract_wav(path, audio_name)
-    run_encode('720p.avs', encode_name, '720p')
+    run_encode(encode_name + '720.avs', encode_name, '720p')
 
 elif resolution == "both":
     #Executes the write_avs function in both modes


### PR DESCRIPTION
This pull request fixes issues with file paths so the user can run multiple instances of encodes at once. The program now generates a .avs file name generated by the user and the resolution of the encode.